### PR TITLE
Longdouble2 osx

### DIFF
--- a/gen/ldc-real.cpp
+++ b/gen/ldc-real.cpp
@@ -175,6 +175,66 @@ ldc::longdouble ldc::longdouble::tan() const
 	return ldouble(d);
 }
 
+ldc::longdouble ldc::longdouble::floor() const
+{
+    // matches man floor(3) description
+    //   floor(+-0) returns +-0.
+    //   floor(+-infinity) returns +-infinity.
+    longdouble tmp;
+    tmp.init(*this).value()->roundToIntegral(llvm::APFloat::rmTowardNegative);
+    return tmp;
+}
+
+ldc::longdouble ldc::longdouble::ceil() const
+{
+    // matches man ceil(3) special values
+    //   ceil(+-0) returns +-0.
+    //   ceil(+-infinity) returns +-infinity.
+    longdouble tmp;
+    tmp.init(*this).value()->roundToIntegral(llvm::APFloat::rmTowardPositive);
+    return tmp;
+}
+
+ldc::longdouble ldc::longdouble::trunc() const
+{
+    // matches man trunc(3) special values
+    //   trunc(+-0) returns +-0.
+    //   trunc(+-infinity) returns +-infinity.
+    longdouble tmp;
+    tmp.init(*this).value()->roundToIntegral(llvm::APFloat::rmTowardZero);
+    return tmp;
+}
+
+ldc::longdouble ldc::longdouble::round() const
+{
+    // matches man round(3) special values
+    //   round(+-0) returns +-0.
+    //   round(+-infinity) returns +-infinity.
+    longdouble tmp;
+    tmp.init(*this).value()->roundToIntegral(llvm::APFloat::rmNearestTiesToAway);
+    return tmp;
+}
+
+ldc::longdouble ldc::longdouble::fmin(longdouble x, longdouble y)
+{
+    // matches man fmin(3) special values and -0,+0 ordering
+    //   If exactly one argument is a NaN, fmin() returns the other
+    //   argument. If both arguments are NaNs, fmin() returns a NaN.
+    return (x.isNaN() ? y :
+            y.isNaN() ? x :
+            x <= y ? x : y);
+}
+
+ldc::longdouble ldc::longdouble::fmax(longdouble x, longdouble y)
+{
+    // matches man fmax(3) special values and -0,+0 ordering
+    //   If exactly one argument is a NaN, fmax() returns the other
+    //   argument. If both arguments are NaNs, fmax() returns a NaN.
+    return (x.isNaN() ? y :
+            y.isNaN() ? x :
+            x >= y ? x : y);
+}
+
 ldc::longdouble ldc::longdouble::fmod(ldc::longdouble x, ldc::longdouble y)
 {
     llvm::APFloat f(*x.value());

--- a/gen/ldc-real.h
+++ b/gen/ldc-real.h
@@ -279,6 +279,13 @@ public:
         return init(v);
     }
 
+    // Apple sdk on osx defines uint64_t as unsigned long long, so long types
+    // are also needed to play with mars.h typedefs (dinteger_t and sinteger_t).
+#if defined(__APPLE__) && defined(__LP64__)
+    longdouble &set(long i) { return set((int64_t)i); }
+    longdouble &set(unsigned long i) { return set((uint64_t)i); }
+#endif
+
 #if defined(_MSC_VER)
     longdouble &set(unsigned long i)
     {
@@ -370,6 +377,14 @@ public:
     longdouble cos() const;
     longdouble tan() const;
 
+    longdouble floor() const;
+    longdouble ceil() const;
+    longdouble trunc() const;
+    longdouble round() const;
+
+    static longdouble fmin(longdouble x, longdouble y);
+    static longdouble fmax(longdouble x, longdouble y);
+
     static longdouble fmod(longdouble x, longdouble y);
     static longdouble ldexp(longdouble ldval, int exp);
 
@@ -439,12 +454,24 @@ inline longdouble sqrtl(longdouble ld) { return ld.sqrt(); }
 inline longdouble sinl (longdouble ld) { return ld.sin(); }
 inline longdouble cosl (longdouble ld) { return ld.cos(); }
 inline longdouble tanl (longdouble ld) { return ld.tan(); }
+inline longdouble floorl (longdouble ld) { return ld.floor(); }
+inline longdouble ceill (longdouble ld) { return ld.ceil(); }
+inline longdouble truncl (longdouble ld) { return ld.trunc(); }
+inline longdouble roundl (longdouble ld) { return ld.round(); }
 
+inline longdouble fminl(longdouble x, longdouble y) { return ldc::longdouble::fmin(x, y); }
+inline longdouble fmaxl(longdouble x, longdouble y) { return ldc::longdouble::fmax(x, y); }
 inline longdouble fmodl(longdouble x, longdouble y) { return ldc::longdouble::fmod(x, y); }
 inline longdouble ldexpl(longdouble ldval, int exp) { return ldc::longdouble::ldexp(ldval, exp); }
 
 inline longdouble fabs (longdouble ld) { return fabsl(ld); }
 inline longdouble sqrt (longdouble ld) { return sqrtl(ld); }
+inline longdouble floor (longdouble ld) { return floorl(ld); }
+inline longdouble ceil (longdouble ld) { return ceill(ld); }
+inline longdouble trunc (longdouble ld) { return truncl(ld); }
+inline longdouble round (longdouble ld) { return roundl(ld); }
+inline longdouble fmin(longdouble x, longdouble y) { return fminl(x,y); }
+inline longdouble fmax(longdouble x, longdouble y) { return fmaxl(x,y); }
 
 inline size_t
 ld_sprint(char* str, int fmt, longdouble x)

--- a/ir/irtype.cpp
+++ b/ir/irtype.cpp
@@ -77,6 +77,8 @@ static inline llvm::Type* getReal80Type(llvm::LLVMContext& ctx)
 
     // only x86 has 80bit float - but no support with MS C Runtime!
     if (anyX86 &&
+        // Check if x87DoubleExtended (64-bit mantissa) selected
+        (APFloat::semanticsPrecision(ldc::longdouble::getFltSemantics()) == 64) &&
 #if LDC_LLVM_VER >= 305
         !global.params.targetTriple.isWindowsMSVCEnvironment()
 #else


### PR DESCRIPTION
These changes allow longdouble2 to compile on OS X.  When I merge this with my ios branch, LDC is able to cross-compile to arm and pass most unittests.  Compared to the hard coded real == double approach I am currently using for iOS, there was only one math unittest failure difference, and that was with hypot().  So it is looking really good foe iOS.

There are problems when compiling for X86_64.  See commit message for details.  Hope this helps.  I am looking forward to having this as the cross-compiling solution.
